### PR TITLE
Allow setting custom AR tool for cross-compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ $(DYLIB): $(OBJS)
 		$(CC) $(LDFLAGS) $(CFLAGS) -fPIC -shared -o $(OUT_DIR)/$@ $(OBJS)
 
 $(STATICLIB): $(OBJS)
-		ar rcs $(OUT_DIR)/$@ $(OBJS)
+		$(AR) rcs $(OUT_DIR)/$@ $(OBJS)
 
 $(OUT_DIR)/$(SRC)/%.o: $(SRC)/%.c
 		mkdir -p $(dir $@)

--- a/README.md
+++ b/README.md
@@ -58,9 +58,10 @@ ideal for being published as a shared library `libvl53l1x`.
 
 ## Cross Compilation
 
-Specify a custom C-compiler using the `VL53L1X_CC` env arg. For example:
+Specify a custom C-compiler and archive utility using the `VL53L1X_CC` and
+`VL53L1X_AR` env args. For example:
 
-```VL53L1X_CC=arm-linux-gnueabihf-gcc cargo build```
+```VL53L1X_CC=arm-linux-gnueabihf-gcc VL53L1X_AR=arm-linux-gnueabihf-ar cargo build```
 
 ## Platform
 

--- a/build.rs
+++ b/build.rs
@@ -4,9 +4,12 @@ use std::process::Command;
 fn main() {
     let mut make = Command::new("make");
     make.arg("libvl53l1x_api.a");
-    // Support explicit CC for cross compilation.
+    // Support explicit CC and AR for cross compilation.
     if let Ok(cc) = env::var("VL53L1X_CC") {
         make.env("CC", cc);
+    }
+    if let Ok(ar) = env::var("VL53L1X_AR") {
+        make.env("AR", ar);
     }
     // Makefile uses OUT_DIR as target.
     run(&mut make);


### PR DESCRIPTION
Just specifying a custom C-compiler is not enough in my case for cross-compilation, one also needs to select the correct AR utility.

Tested using the Linaro Arm-toolchain, cross-compiling for a custom Arm Cortex-A53 SoM.